### PR TITLE
Change the quicklisp dependency to be optional

### DIFF
--- a/lem-extension-manager.asd
+++ b/lem-extension-manager.asd
@@ -1,4 +1,6 @@
 (defsystem "lem-extension-manager"
-  :depends-on ()
+  :depends-on (:alexandria)
   :serial t
-  :components ((:file "main")))
+  :components ((:file "source")
+               (:file "quicklisp" :if-feature :quicklisp)
+               (:file "main")))

--- a/quicklisp.lisp
+++ b/quicklisp.lisp
@@ -1,0 +1,56 @@
+(defpackage :lem-extension-manager/quicklisp
+  (:use :cl :uiop :lem-extension-manager/source)
+  (:export :make-quicklisp))
+
+(in-package :lem-extension-manager/quicklisp)
+
+(defun url-not-suitable-error-p (condition)
+  (<= 400 (ql-http:unexpected-http-status-code condition) 499))
+
+(defun fetch-gzipped-version (url file &key quietly)
+  (let ((gzipped-temp (merge-pathnames "gzipped.tmp" file)))
+    (ql-http:fetch url gzipped-temp :quietly quietly)
+    (ql-gunzipper:gunzip gzipped-temp file)
+    (delete-file-if-exists gzipped-temp)
+    (probe-file file)))
+
+(defun maybe-fetch-tgzipped (url file &key quietly)
+  (handler-case
+      (fetch-gzipped-version url file :quietly quietly)
+    (ql-http:unexpected-http-status (condition)
+      (cond ((url-not-suitable-error-p condition)
+             (ql-http:fetch url file :quietly quietly)
+             (probe-file file))
+            (t
+             (error condition))))))
+
+(defstruct (quicklisp (:include source)))
+
+(defvar *quicklisp-system-list*
+  (remove-duplicates
+   (mapcar #'ql-dist:release (ql:system-list))))
+
+(defmethod download-source ((source quicklisp) (output-location String))
+  (let* ((ql:*local-project-directories* (list *packages-directory*))
+         (output-dir (concatenate 'string
+                      (namestring *packages-directory*) output-location))
+         (release (find (source-name source)
+                        *quicklisp-system-list*
+                        :key #'ql-dist:project-name
+                        :test #'string=))
+         (url (ql-dist:archive-url release))
+         (name (source-name source))
+         (tarfile (concatenate 'string name ".tar")))
+    (if release
+        (prog1 output-dir
+          (uiop:with-current-directory (*packages-directory*)
+            (maybe-fetch-tgzipped url tarfile :quietly t)
+            (ql-minitar:unpack-tarball tarfile)
+            (delete-file tarfile)
+            (uiop/cl:rename-file (ql-dist:prefix release) output-location)))
+        (error "Package ~a not found!." (source-name source)))))
+
+(defun %register-maybe-quickload (name)
+  (uiop:symbol-call :quicklisp :register-local-projects)
+  (ql:quickload (alexandria:make-keyword name) :silent t))
+

--- a/source.lisp
+++ b/source.lisp
@@ -1,0 +1,14 @@
+(defpackage :lem-extension-manager/source
+  (:use :cl)
+  (:export :source
+           :download-source
+           :local))
+
+(in-package :lem-extension-manager/source)
+
+(defstruct source name)
+
+(defstruct (local (:include source)))
+
+(defgeneric download-source (source output-location)
+  (:documentation "It downloads the SOURCE to the desired location."))


### PR DESCRIPTION
I use lem with guix, without quicklisp, this PR makes the lem-extension-manager have only an optional dependency on quicklisp if the `:quicklisp` keyword is in `*features*`.

I also add an explicit dependency on alexandria and replace usage of str:concat with concatenate.